### PR TITLE
Add 3 warnings and fix some message descriptions

### DIFF
--- a/_data/lex.yml
+++ b/_data/lex.yml
@@ -64,9 +64,9 @@
 - warning: -W#warnings
   message: '%0'
 - warning: -Wdisabled-macro-expansion
-  message: disabled expansion of recursive macro"
+  message: disabled expansion of recursive macro
 - warning: -Wunused-macros
-  message: macro is not used"
+  message: macro is not used
 - warning: -Wundef
   message: '%0 is not defined, evaluates to 0'
 - warning: -Wambiguous-macro
@@ -84,7 +84,7 @@
 - warning: -Wunknown-pragmas
   message: pragma STDC FENV_ACCESS ON is not supported, ignoring pragma
 - warning: -Winvalid-token-paste
-  message: pasting formed '%0', an invalid preprocessing token", DefaultError
+  message: pasting formed '%0', an invalid preprocessing token, DefaultError
 - warning: -Wc++98-compat-pedantic
   message: '#line number greater than 32767 is incompatible with C++98'
 - warning: -Wignored-attributes

--- a/_data/parse.yml
+++ b/_data/parse.yml
@@ -2,7 +2,7 @@
 - warning: -Wc++98-compat-pedantic
   message: extra '' outside of a function is incompatible with C++98
 - warning: -Wextra-semi
-  message: extra '' after member function definition
+  message: extra ';' after member function definition
 - warning: -Wduplicate-decl-specifier
   message: duplicate '%0' declaration specifier
 - warning: -Wc++98-compat-pedantic
@@ -73,8 +73,7 @@
   message: use of right-shift operator ('') in template argument will require
     parentheses in C++11
 - warning: -Wc++98-compat
-  message: consecutive right angle brackets are incompatible with C++98 (use '
-    ')
+  message: consecutive right angle brackets are incompatible with C++98 (use '> >')
 - warning: -Wc++98-compat-pedantic
   message: extern templates are incompatible with C++98
 - warning: -Wstatic-inline-explicit-instantiation

--- a/_data/semantic.yml
+++ b/_data/semantic.yml
@@ -18,6 +18,8 @@
     is %1
 - warning: -Wvla
   message: variable length array used
+- warning: -Wvla-extension
+  message: variable length arrays are a C99 feature
 - warning: -Winitializer-overrides
   message: subobject initialization overrides initialization of other fields within
     its enclosing subobject
@@ -281,7 +283,7 @@
   message: dependent nested name specifier '%0' for friend template declaration
     is not supported ignoring this friend declaration
 - warning: -Wweak-vtables
-  message: '%0 has no out-of-line virtual method definitions its vtable will be
+  message: '%0 has no out-of-line virtual method definitions; its vtable will be
     emitted in every translation unit'
 - warning: -Wweak-template-vtables
   message: explicit template instantiation %0 will emit a vtable in every translation
@@ -1112,5 +1114,9 @@
   message: instance variable %0 is being directly accessed
 - warning: -Wdocumentation
   message: not a Doxygen trailing comment
+- warning: -Wdocumentation
+  message: parameter '%0' not found in the function declaration
 - warning: -Wgnu-conditional-omitted-operand
   message: "use of GNU ?: conditional expression extension, omitting middle operand"
+- warning: -Wnested-anon-types
+  message: "anonymous types declared in an anonymous union/struct are an extension"


### PR DESCRIPTION
- Add some missing warnings seen in the wild: -Wdocumentation, -Wvla-
  extension and -Wnested-anon-types (anonymous-union) .
- Complete description for Wweak-vtables (warn-weak-vtables) in semantic
  file
- Fix missing operands descriptions in parse file
- Remove extra quotes in lex file
